### PR TITLE
Performance Enhancements

### DIFF
--- a/base32h.js
+++ b/base32h.js
@@ -127,7 +127,9 @@
      * @param {string} char - The character to pad with.
      * @returns {string} - The padded string.
      */
-    function pad(value, alignment = 8, char = '0') {
+    function pad(value, alignment, char) {
+        alignment = alignment || 8;
+        char = char || '0';
         value = typeof value === 'string' ? value : ''+value;
         const pad = value.length % alignment;
         if (pad) {

--- a/spec.js
+++ b/spec.js
@@ -126,3 +126,30 @@ test('Base32H Binary: Decode', function (t) {
     testBinDecode(t, 'zZzZzZzZzZzZzZzZ', [...uint40, ...uint40]);
     t.end();
 });
+
+test('Base32H Digit: Encode Digit', function (t) {
+    t.equal(base32h.encodeDigit(0), '0', "Encode 0 to '0'");
+    t.equal(base32h.encodeDigit(10), 'A', "Encode 10 to 'A'");
+    t.equal(base32h.encodeDigit(31), 'Z', "Encode 31 to 'Z'");
+    t.throws(
+        () => { base32h.encodeDigit(-1) },
+        /Cannot read property '0' of undefined/,
+        "Encode -1 should throw"
+    );
+    t.throws(
+        () => { base32h.encodeDigit(32) },
+        /Cannot read property '0' of undefined/,
+        "Encode 32 should throw"
+    );
+    t.end();
+});
+
+test('Base32H Digit: Decode Digit', function (t) {
+    t.equal(base32h.decodeDigit('0'), 0, "Decode '0' to 0");
+    t.equal(base32h.decodeDigit('A'), 10, "Decode 'A' to 10");
+    t.equal(base32h.decodeDigit('Z'), 31, "Decode 'Z' to 31");
+    t.equal(base32h.decodeDigit('!'), -1, "Decode '!' to -1");
+    // This isn't a problem, just document here in test.
+    t.equal(base32h.decodeDigit(''), 0, "Decode '' to 0");
+    t.end();
+});


### PR DESCRIPTION
I've spent some time making performance enhancements to base32h.js.

Average runtime of original code vs changed code across 500,000 calls:
- encode: 0.0025 vs 0.0021 : +18%
- decode: 0.0034 vs 0.0031 : +10%
- encodeBin: 0.0044 vs 0.003 : +31%
- decodeBin: 0.0131 vs 0.0063 : +52%

[report.xlsx](https://github.com/Base32H/base32h.js/files/5907844/report.xlsx)

The performance numbers jump around a bit each run but trend faster with these changes.

You can find the code used to measure the performance in the perf branch of my fork.
https://github.com/theroyalwhee0/base32h.js/tree/perf/perf/

Most of the improvements are gained by reducing: object creation, cloning data, and re-parsing
